### PR TITLE
Fixes parsing of CacheMembers when only strings  are used

### DIFF
--- a/src/SetsCache.Tests/CacheKeyParseTests.cs
+++ b/src/SetsCache.Tests/CacheKeyParseTests.cs
@@ -18,5 +18,28 @@ namespace SetsCache.Tests
       Assert.Equal("OR", item.State);
       Assert.Equal("97209", item.Zip);
     }
+
+    [Fact]
+    public void ParsesOnlyStrings()
+    {
+      var serializer = new CacheMemberSerializer();
+      var key = "Sandy-UT";
+      var item = serializer.Parse<StringsOnlySearch>(key);
+
+      Assert.Equal("Sandy", item.City);
+      Assert.Equal("UT", item.State);
+    }
+
+    [Fact]
+    public void ParsesOnlyInts()
+    {
+      var serializer = new CacheMemberSerializer();
+      var key = "123";
+      var item = serializer.Parse<IntsOnlySearch>(key);
+
+      Assert.Equal(1, item.Beds);
+      Assert.Equal(2, item.Baths);
+      Assert.Equal(3, (int)item.PropertyType);
+    }
   }
 }

--- a/src/SetsCache.Tests/Models/IntsOnlySearch.cs
+++ b/src/SetsCache.Tests/Models/IntsOnlySearch.cs
@@ -1,0 +1,12 @@
+namespace SetsCache.Tests
+{
+  public class IntsOnlySearch
+  {
+    [CacheMember(1)]
+    public int Beds { get; set; }
+    [CacheMember(2)]
+    public int Baths { get; set; }
+    [CacheMember(3)]
+    public PropertyType PropertyType { get; set; }
+  }
+}

--- a/src/SetsCache.Tests/Models/StringsOnlySearch.cs
+++ b/src/SetsCache.Tests/Models/StringsOnlySearch.cs
@@ -1,0 +1,10 @@
+namespace SetsCache.Tests
+{
+  public class StringsOnlySearch
+  {
+    [CacheMember(1)]
+    public string City { get; set; }
+    [CacheMember(2)]
+    public string State { get; set; }
+  }
+}

--- a/src/SetsCache/CacheMemberSerializer.cs
+++ b/src/SetsCache/CacheMemberSerializer.cs
@@ -134,14 +134,14 @@ namespace SetsCache
         else
         {
           if (key.Substring(index, 1) == "-")
-          {
-            var chars = key.Substring(index + 1)
-              .TakeWhile(f => !delimiters.Contains(f))
-              .ToArray();
+            index++;
 
-            prop.SetValue(item, new string(chars));
-            index += chars.Length + 1;
-          }
+          var chars = key.Substring(index)
+            .TakeWhile(f => !delimiters.Contains(f))
+            .ToArray();
+
+          prop.SetValue(item, new string(chars));
+          index += chars.Length + 1;
         }
       }
 


### PR DESCRIPTION
See https://www.pivotaltracker.com/story/show/164476233