### PR TITLE
Updated StackExchange.Redis v2.0

### DIFF
--- a/src/SetsCache.Redis/SetsCache.Redis.csproj
+++ b/src/SetsCache.Redis/SetsCache.Redis.csproj
@@ -22,7 +22,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.App" />
-    <PackageReference Include="Microsoft.Extensions.Caching.Redis" Version="2.2.0" />
+    <PackageReference Include="Microsoft.Extensions.Caching.StackExchangeRedis" Version="2.2.0" />
     <PackageReference Include="protobuf-net" Version="2.4.0" />
   </ItemGroup>
 

--- a/src/SetsCache.Tests/RedisTests.cs
+++ b/src/SetsCache.Tests/RedisTests.cs
@@ -13,7 +13,7 @@ namespace SetsCache.Tests
     public RedisTests()
     {
       services = new ServiceCollection()
-        .AddDistributedRedisCache(o =>
+        .AddStackExchangeRedisCache(o =>
         {
           o.Configuration = "localhost:6388";
           o.InstanceName = "RedisTests";

--- a/src/SetsCache.Tests/SeoTests.cs
+++ b/src/SetsCache.Tests/SeoTests.cs
@@ -1,6 +1,6 @@
 using System;
 using System.Threading.Tasks;
-using Microsoft.Extensions.Caching.Redis;
+using Microsoft.Extensions.Caching.StackExchangeRedis;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Options;
 using StackExchange.Redis;
@@ -15,7 +15,7 @@ namespace SetsCache.Tests
     public SeoTests()
     {
       services = new ServiceCollection()
-        .AddDistributedRedisCache(o =>
+        .AddStackExchangeRedisCache(o =>
         {
           o.Configuration = "localhost:6388";
           o.InstanceName = "SeoTests:";

--- a/src/SetsCache.Tests/Services/SeoFiller.cs
+++ b/src/SetsCache.Tests/Services/SeoFiller.cs
@@ -1,6 +1,6 @@
 using System.Threading;
 using System.Threading.Tasks;
-using Microsoft.Extensions.Caching.Redis;
+using Microsoft.Extensions.Caching.StackExchangeRedis;
 using Microsoft.Extensions.Options;
 using StackExchange.Redis;
 

--- a/src/SetsCache.Tests/Services/SeoService.cs
+++ b/src/SetsCache.Tests/Services/SeoService.cs
@@ -1,7 +1,7 @@
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
-using Microsoft.Extensions.Caching.Redis;
+using Microsoft.Extensions.Caching.StackExchangeRedis;
 using Microsoft.Extensions.Options;
 using StackExchange.Redis;
 

--- a/src/SetsCache.Tests/SetsCache.Tests.csproj
+++ b/src/SetsCache.Tests/SetsCache.Tests.csproj
@@ -7,11 +7,11 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.Caching.StackExchangeRedis" Version="2.2.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.9.0" />
     <PackageReference Include="xunit" Version="2.4.0" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.0" />
     <PackageReference Include="Microsoft.AspNetCore.App" />
-    <PackageReference Include="Microsoft.Extensions.Caching.Redis" Version="2.2.0" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
We need to use Redis v2.0 to fix this "Out of memory Exception" link: https://github.com/StackExchange/StackExchange.Redis/issues/422

Updated Microsoft.Extensions.Caching.Redis  to Microsoft.Extensions.Caching.StackExchangeRedis to use StackExchange.Redis v2.0 Link: https://github.com/aspnet/Announcements/issues/322

